### PR TITLE
fix: dont replace incorrectly for single quotes

### DIFF
--- a/lib/rules/prefer.js
+++ b/lib/rules/prefer.js
@@ -275,19 +275,28 @@ module.exports = {
       const ignoreSingleQuotes =
         matches.reduce((all, match) => {
           const value = match[0];
-          let isQuote = false
+          let isQuote = false;
 
           if (pluginOptions.inputFormat === "all" && isSingleQuote(value)) {
-            isQuote = true
+            isQuote = true;
           }
-          if (pluginOptions.inputFormat === "character" && value === MAPPINGS.singleQuote.character) {
-            isQuote = true
+          if (
+            pluginOptions.inputFormat === "character" &&
+            value === MAPPINGS.singleQuote.character
+          ) {
+            isQuote = true;
           }
-          if (pluginOptions.inputFormat === "unicode" && value === MAPPINGS.singleQuote.unicode) {
-            isQuote = true
+          if (
+            pluginOptions.inputFormat === "unicode" &&
+            value === MAPPINGS.singleQuote.unicode
+          ) {
+            isQuote = true;
           }
-          if (pluginOptions.inputFormat === "alphanumeric" && value === MAPPINGS.singleQuote.alphanumeric) {
-            isQuote = true
+          if (
+            pluginOptions.inputFormat === "alphanumeric" &&
+            value === MAPPINGS.singleQuote.alphanumeric
+          ) {
+            isQuote = true;
           }
 
           return all + (isQuote ? 1 : 0);
@@ -340,9 +349,9 @@ module.exports = {
 
                 if (isSingleQuote && ignoreSingleQuotes) {
                   replacement = null;
+                } else {
+                  seek(characterData.value.length - 1);
                 }
-
-                seek(characterData.value.length - 1);
               }
 
               if (replacement) {

--- a/tests/libs/rules/prefer.js
+++ b/tests/libs/rules/prefer.js
@@ -209,5 +209,33 @@ ruleTester.run("smart-quotes", rule, {
         },
       ],
     },
+
+    {
+      code: `
+        <Text>
+          Uh-uh. You know, with you it&apos;s always, &apos;Me, me, me!&apos; Wll, 
+          guess that! Now it&apos;s my turn! So you just shut up and pay 
+          attention! You&apos;re mean to me. You insult me and you don&apos;t 
+          appreciate anything that I do! You&apos;re always pushing me around 
+          or pushing me away.
+        </Text>
+      `,
+      output: `
+        <Text>
+          Uh-uh. You know, with you it&apos;s always, &apos;Me, me, me!&apos; Wll, 
+          guess that! Now it&apos;s my turn! So you just shut up and pay 
+          attention! You&apos;re mean to me. You insult me and you don&apos;t 
+          appreciate anything that I do! You&apos;re always pushing me around 
+          or pushing me away.
+        </Text>
+      `,
+      options: ["all"],
+      errors: [
+        {
+          message: `Strings must use curly quotes.`,
+          type: "JSXText",
+        },
+      ],
+    }
   ],
 });


### PR DESCRIPTION
# What's the problem?

Currently, if there are multiple single quotes, the plugin will replace single quotes with an ampersand rather than skipping over the quotes. 
